### PR TITLE
update parametersets related to mpi ranking in the platform.xml for fugaku

### DIFF
--- a/platform/fugaku/platform.xml
+++ b/platform/fugaku/platform.xml
@@ -29,9 +29,10 @@
         <parameter name="mpi_shape" mode="python">
             "" if "$nodeshape" == "" else "#PJM --mpi “shape=$nodes"
         </parameter>
-        <parameter name="mpi_ranking">""</parameter><!-- bychip;bynode-->
+	<parameter name="mpi_ranking">""</parameter><!-- bychip;bynode-->
+        <parameter name="mpi_ranking_order">XY</parameter><!-- XY;YX;XYZ..-->	
         <parameter name="mpi_ranking_conf" mode="python">
-            "" if "$nodeshape" == "" else f"#PJM --mpi rank-mab-${mpi_ranking}={'XY' if len('$nodes'.split('x')) == 2 else 'XYZ'}"
+		"" if "$mpi_ranking" == "" else f"#PJM --mpi rank-map-${mpi_ranking}=${mpi_ranking_order}"
         </parameter>
         <parameter name="taskspernode" type="int">1</parameter>
         <parameter name="threadspertask" type="int">1</parameter>


### PR DESCRIPTION
1. add a parameter `mpi_ranking_order`, which allows to specify the order of node/process: e.g., XY; YX; XYZ..
2. update the parameter `mpi_ranking_conf`, in the end, if `mpi_ranking` is set as `bychip` or `bynode`, it will add the `#PJM --mpi rank-map-${mpi_ranking}=${mpi_ranking_order}`.